### PR TITLE
fixed iframes height

### DIFF
--- a/docs/css/home.css
+++ b/docs/css/home.css
@@ -88,11 +88,11 @@
     background-color: var(--creamColor);
 }
 .demos .example.with-utility iframe {
-    min-height: 770px;
+    min-height: 570px;
     box-shadow: 0px 10px 20px rgba(0, 0, 0, .2);
 }
 .demos .example.without-utility iframe {
-    min-height: 730px;
+    min-height: 530px;
     margin-bottom: 1em;
 }
 


### PR DESCRIPTION
For https://github.com/bitovi/velocirender/issues/12#issuecomment-458686839

@matthewp I reverted to the initial height, this is how it looks when the height viewport is 800px:

<img width="1278" alt="screen shot 2019-01-29 at 3 19 00 pm" src="https://user-images.githubusercontent.com/950214/51941198-99fed180-23d9-11e9-9e61-2bf8fdd614ef.png">