### PR TITLE
Fallback to client-side only for non-supporting browsers

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -60,7 +60,8 @@ function render(options, mutationsUrl, request, response, next) {
 
 	// Generate and send HTML right away. For non-supporting browsers
 	// This means partially rendered content + client-side only.
-	let html = "<!doctype html>" + zone.data.html;
+	let docHTML = zone.data.html || zone.data.document.documentElement.outerHTML;
+	let html = "<!doctype html>" + docHTML;
 	sendHTML(response, html);
 	return html;
 }

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -57,18 +57,12 @@ function render(options, mutationsUrl, request, response, next) {
 
 	let runPromise = zone.run(void 0);
 	runPromise.catch(logErrors(zone, next));
-	
-	if(supportsIncremental(request)) {
-		let html = "<!doctype html>" + zone.data.html;
-		sendHTML(response, html);
-		return html;
-	}
-	else {
-		runPromise = runPromise.then(data => {
-			let html = "<!doctype html>" + data.html;
-			sendHTML(response, html);
-		});
-	}
+
+	// Generate and send HTML right away. For non-supporting browsers
+	// This means partially rendered content + client-side only.
+	let html = "<!doctype html>" + zone.data.html;
+	sendHTML(response, html);
+	return html;
 }
 
 const mutationsExp = /&quot;\/_mutations\/[0-9]+&quot;/g;

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -23,7 +23,7 @@ describe("CLI", function() {
 			let res = await fetch('http://localhost:8055');
 			let html = await res.text();
 
-			assert.ok(/id="app"/.test(html), "Rendered with the executed JavaScript");
+			assert.ok(/<main>/.test(html), "Rendered with the initial HTML");
 		});
 	})
 });


### PR DESCRIPTION
For browsers that do not support the necessary APIs (mostly this means
ReadableStream and iframe srcdoc) fallback to serving the
client-side app. Since Velocirender is primarily about speed we should
prefer client-side over full SSR.