### PR TITLE
Prevent using HTML cache for non-IR supporting browsers

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -24,18 +24,21 @@ function handler(serverOptions, resource) {
 
 		// Test if this is a cached HTML page.
 		let mutationsUrl = `/_mutations/${Date.now()}`;
-		if(cacheMap.has(request.url)) {
+		let useHtmlCache = cacheHtml && supportsIncremental(request);
+		if(useHtmlCache && cacheMap.has(request.url)) {
 			let html = cacheMap.get(request.url);
 			let newHtml = replaceMutationUrl(html, mutationsUrl);
 			sendHTML(response, newHtml);
 		}
+
+		
 
 		// For a remote resource we have to wait for stuff to download the first time.
 		if(!resource.ready) {
 			resource.whenReady().then(() => {
 				let html = render(options, mutationsUrl, request, response, next);
 
-				if(cacheHtml && html && !cacheMap.has(request.url)) {
+				if(useHtmlCache && html && !cacheMap.has(request.url)) {
 					cacheMap.set(request.url, html);
 				}
 			}, next);
@@ -44,7 +47,7 @@ function handler(serverOptions, resource) {
 		// Render the request with zones/jsdom
 		let html = render(options, mutationsUrl, request, response, next);
 
-		if(cacheHtml && html && !cacheMap.has(request.url)) {
+		if(useHtmlCache && html && !cacheMap.has(request.url)) {
 			cacheMap.set(request.url, html);
 		}
 	}
@@ -62,7 +65,9 @@ function render(options, mutationsUrl, request, response, next) {
 	// This means partially rendered content + client-side only.
 	let docHTML = zone.data.html || zone.data.document.documentElement.outerHTML;
 	let html = "<!doctype html>" + docHTML;
+
 	sendHTML(response, html);
+
 	return html;
 }
 

--- a/lib/supports-incremental.js
+++ b/lib/supports-incremental.js
@@ -6,5 +6,5 @@ module.exports = function(requestOrHeaders) {
 	let agent = useragent.lookup(uaString);
 	let browser = useragent.is(uaString);
 
-	return agent.family !== "Edge" && (browser.chrome || browser.safari);
+	return agent.family !== "Edge" && (browser.chrome);
 };


### PR DESCRIPTION
Don't use the HTML cache when the browser doesn't support IR. This
prevents a condition where the first render we cache HTML, and for IR
supporting browsers it means we don't get IR, for non-supporting it
could mean we do anyways...