### PR TITLE
Increase the timeout

### DIFF
--- a/lib/zone.js
+++ b/lib/zone.js
@@ -20,7 +20,7 @@ function createZoneForRequest(options, mutationsUrl, request, response) {
 		cookies(request, response)
 	];
 
-	let timeoutZone = timeout(5000);
+	let timeoutZone = timeout(30000);
 	zones.push(timeoutZone);
 
 	if(debug.enabled) {


### PR DESCRIPTION
Timeouts aren't super important for incremental rendering since HTML is
not waited on. I'm not 100% sure its needed at all, actually. Keeping it
in for now, could be useful in some scenarios to figure out what is
happening on the server.