### PR TITLE
Reenable IR with Safari

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -1,10 +1,11 @@
 const {createZoneForRequest, isTimeoutError} = require("./zone");
 const LRU = require('quick-lru');
 const supportsIncremental = require("./supports-incremental");
+const HTMLCache = require("./html-cache");
 
 function handler(serverOptions, resource) {
 	let cacheHtml = serverOptions.cacheHtml !== false;
-	let cacheMap = new LRU({ maxSize: 1000 });
+	let cacheMap = new HTMLCache();
 	let streamMap = new LRU({ maxSize: 1000 });
 
 	let options = Object.freeze({
@@ -25,19 +26,20 @@ function handler(serverOptions, resource) {
 		// Test if this is a cached HTML page.
 		let mutationsUrl = `/_mutations/${Date.now()}`;
 		let useHtmlCache = cacheHtml && supportsIncremental(request);
-		if(useHtmlCache && cacheMap.has(request.url)) {
-			let html = cacheMap.get(request.url);
+		if(useHtmlCache && cacheMap.has(request)) {
+			let html = cacheMap.get(request);
 			let newHtml = replaceMutationUrl(html, mutationsUrl);
 			sendHTML(response, newHtml);
 		}
 
 		// For a remote resource we have to wait for stuff to download the first time.
+
 		if(!resource.ready) {
 			resource.whenReady().then(() => {
 				let html = render(options, mutationsUrl, request, response, next);
 
-				if(useHtmlCache && html && !cacheMap.has(request.url)) {
-					cacheMap.set(request.url, html);
+				if(useHtmlCache && html && !cacheMap.has(request)) {
+					cacheMap.set(request, html);
 				}
 			}, next);
 		}
@@ -45,8 +47,8 @@ function handler(serverOptions, resource) {
 		// Render the request with zones/jsdom
 		let html = render(options, mutationsUrl, request, response, next);
 
-		if(useHtmlCache && html && !cacheMap.has(request.url)) {
-			cacheMap.set(request.url, html);
+		if(useHtmlCache && html && !cacheMap.has(request)) {
+			cacheMap.set(request, html);
 		}
 	}
 

--- a/lib/html-cache.js
+++ b/lib/html-cache.js
@@ -1,0 +1,41 @@
+const LRU = require('quick-lru');
+const supportsPreloadFetch = require("./supports-preloadfetch");
+
+class HTMLCache {
+	constructor() {
+		this.withPreload = new LRU({ maxSize: 1000 });
+		this.noPreload = new LRU({ maxSize: 1000 });
+	}
+
+	has(request) {
+		let url = request.url;
+
+		if(!supportsPreloadFetch(request)) {
+			return this.noPreload.has(url);
+		} else {
+			return this.withPreload.has(url);
+		}
+	}
+
+	get(request) {
+		let url = request.url;
+
+		if(!supportsPreloadFetch(request)) {
+			return this.noPreload.get(url);
+		} else {
+			return this.withPreload.get(url);
+		}
+	}
+
+	set(request, html) {
+		let cache = this.withPreload;
+
+		if(!supportsPreloadFetch(request)) {
+			cache = this.noPreload;
+		}
+
+		cache.set(request.url, html);
+	}
+}
+
+module.exports = HTMLCache;

--- a/lib/supports-incremental.js
+++ b/lib/supports-incremental.js
@@ -6,5 +6,5 @@ module.exports = function(requestOrHeaders) {
 	let agent = useragent.lookup(uaString);
 	let browser = useragent.is(uaString);
 
-	return agent.family !== "Edge" && (browser.chrome);
+	return agent.family !== "Edge" && (browser.chrome || browser.safari);
 };

--- a/lib/supports-preloadfetch.js
+++ b/lib/supports-preloadfetch.js
@@ -1,0 +1,8 @@
+var useragent = require("useragent");
+
+module.exports = function(headers = {}) {
+	var uaString = headers["user-agent"] || "";
+	var browser = useragent.is(uaString);
+
+	return !browser.safari;
+};

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "can-zone": "^1.0.0",
     "can-zone-jsdom": "^2.0.1",
     "done-serve": "^3.2.0",
-    "done-ssr": "^3.2.0",
+    "done-ssr": "^3.2.7",
     "meow": "^5.0.0",
     "mime": "^2.4.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
This reenables IR with Safari by upgrading done-ssr and keeping a
separate HTML cache for browsers with support for preload fetching and
those without.