### PR TITLE
Styles adjustments

### DIFF
--- a/docs/css/base.css
+++ b/docs/css/base.css
@@ -23,8 +23,17 @@ button .icon {
     font-size: 1.1em;
     margin-right: 3px;
 }
-p {
+p,
+li {
     line-height: 1.5;
+}
+
+li {
+    margin-bottom: 1em;
+}
+
+ul {
+    margin-bottom: 1em;
 }
 
 a {

--- a/docs/css/home.css
+++ b/docs/css/home.css
@@ -183,6 +183,9 @@
     padding-left: 2em;
     border-left: solid 5px var(--secondaryColor);
 }
+.article .article-content .button {
+    margin-top: 1em;
+}
 .article .article-content .article-title {
     font-weight: normal;
     margin-bottom: 0;

--- a/docs/css/home.css
+++ b/docs/css/home.css
@@ -128,11 +128,11 @@
     margin: 3em -3em 0 -3em;
 }
 .demos .installation pre {
-    width: 970px;
     background-color: black;
-    padding: 2em 0;
+    padding: 2em;
     border-radius: 10px;
     overflow-x: auto;
+    white-space: pre-line;
 }
 @media screen and (max-width: 1028px) {
     .demos .installation pre {


### PR DESCRIPTION
Adjusted list in the article block
<img width="766" alt="screen shot 2019-02-08 at 3 41 46 pm" src="https://user-images.githubusercontent.com/950214/52508195-56664d80-2bb9-11e9-8a7f-7af1ac7d6b94.png">

And a fix for #50 
<img width="1121" alt="screen shot 2019-02-08 at 3 48 34 pm" src="https://user-images.githubusercontent.com/950214/52508210-6120e280-2bb9-11e9-9c7b-5fea19e79919.png">
